### PR TITLE
Removed backup file that was causing issues with ansible-galaxy

### DIFF
--- a/vars/main.yml~
+++ b/vars/main.yml~
@@ -1,5 +1,0 @@
----
-# vars file for eucalyptus-configureDNS
-
-dns_system_properties:
-- {'name': "system.dns.dnsdomain", value: "{{   }}" }


### PR DESCRIPTION
- extracting JohnPreston.eucalyptus-configureDNS to /etc/ansible/roles/JohnPreston.eucalyptus-configureDNS
  Traceback (most recent call last):
  File "/usr/local/bin/ansible-galaxy", line 957, in <module>
    main()
  File "/usr/local/bin/ansible-galaxy", line 951, in main
    fn(args, options, parser)
  File "/usr/local/bin/ansible-galaxy", line 837, in execute_install
    installed = install_role(role.get("name"), role.get("version"), tmp_file, options)
  File "/usr/local/bin/ansible-galaxy", line 566, in install_role
    role_tar_file.extract(member, role_path)
  File "/usr/local/Cellar/python/2.7.10/Frameworks/Python.framework/Versions/2.7/lib/python2.7/tarfile.py", line 2109, in extract
    self._extract_member(tarinfo, os.path.join(path, tarinfo.name))
  File "/usr/local/Cellar/python/2.7.10/Frameworks/Python.framework/Versions/2.7/lib/python2.7/tarfile.py", line 2185, in _extract_member
    self.makefile(tarinfo, targetpath)
  File "/usr/local/Cellar/python/2.7.10/Frameworks/Python.framework/Versions/2.7/lib/python2.7/tarfile.py", line 2225, in makefile
    with bltn_open(targetpath, "wb") as target:
  IOError: [Errno 21] Is a directory: '/etc/ansible/roles/JohnPreston.eucalyptus-configureDNS/vars'
